### PR TITLE
Refactor rtpkg helper class

### DIFF
--- a/cpp_pubsub/CMakeLists.txt
+++ b/cpp_pubsub/CMakeLists.txt
@@ -6,7 +6,6 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-
 include_directories(
   include
 )
@@ -16,7 +15,8 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
-# rtpkg_msg custom msg
+# Add rtpkg for helper function
+find_package(rtpkg REQUIRED)
 find_package(rtpkg_msg REQUIRED)
 
 # Pub
@@ -24,8 +24,10 @@ add_executable(pub src/pub_single.cpp)
 ament_target_dependencies(pub rclcpp std_msgs)
 
 # Sub
-add_executable(sub src/sub_multi.cpp src/helper.cpp)
-ament_target_dependencies(sub rclcpp std_msgs rtpkg_msg)
+add_executable(sub src/sub_multi.cpp)
+target_link_libraries(sub ${RTPKG_LIBRARIES})
+ament_target_dependencies(sub rclcpp std_msgs rtpkg rtpkg_msg)
+
 
 install(TARGETS
   pub
@@ -52,7 +54,5 @@ if(BUILD_TESTING)
   #set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
-
-ament_export_include_directories(include)
 
 ament_package()

--- a/cpp_pubsub/CMakeLists.txt
+++ b/cpp_pubsub/CMakeLists.txt
@@ -36,10 +36,6 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
-install(DIRECTORY include/
-  DESTINATION include/
-)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights

--- a/cpp_pubsub/CMakeLists.txt
+++ b/cpp_pubsub/CMakeLists.txt
@@ -6,10 +6,6 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-include_directories(
-  include
-)
-
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/cpp_pubsub/package.xml
+++ b/cpp_pubsub/package.xml
@@ -10,6 +10,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   
+  <build_depend>rtpkg</build_depend>
   <build_depend>rtpkg_msg</build_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/cpp_pubsub/src/sub_multi.cpp
+++ b/cpp_pubsub/src/sub_multi.cpp
@@ -20,7 +20,7 @@
 #include "std_msgs/msg/string.hpp"
 #include "std_msgs/msg/int16.hpp"
 
-#include "cpp_pubsub/helper.hpp"
+#include "rtpkg/helper.hpp"
 #include "rtpkg_msg/msg/rndnum.hpp"
 
 using namespace std::chrono_literals;        // For timer

--- a/rtpkg/CMakeLists.txt
+++ b/rtpkg/CMakeLists.txt
@@ -5,12 +5,46 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+include_directories(
+  include
+)
+
 find_package(ament_cmake REQUIRED)
  
+set(LIB_NAME rtpkg_helper)
+
+add_library(${LIB_NAME} src/helper.cpp)
+ 
 # Gen launch files.
-install(DIRECTORY
-  launch
+install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}/
 )
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+# Reference: http://www.robotandchisel.com/2020/08/25/etherbotix/#exporting-libraries
+install(
+  TARGETS
+  ${LIB_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(include)
+ament_export_libraries(${LIB_NAME})
 
 ament_package()

--- a/rtpkg/include/rtpkg/helper.hpp
+++ b/rtpkg/include/rtpkg/helper.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef CPP_PUBSUB__HELPER_HPP_
-#define CPP_PUBSUB__HELPER_HPP_
+#ifndef RTPKG__HELPER_HPP_
+#define RTPKG__HELPER_HPP_
 
 #include <random>
 
@@ -38,4 +38,4 @@ private:
   void setMax(int & mx);
 };
 
-#endif    // CPP_PUBSUB__HELPER_HPP_
+#endif    // RTPKG__HELPER_HPP_

--- a/rtpkg/package.xml
+++ b/rtpkg/package.xml
@@ -9,9 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>cpp_pubsub</exec_depend>
-  <exec_depend>py_pubsub</exec_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rtpkg/src/helper.cpp
+++ b/rtpkg/src/helper.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cpp_pubsub/helper.hpp"
+#include "rtpkg/helper.hpp"
 
 rtpkg::rtpkg() {}
 


### PR DESCRIPTION
- Shift rtpkg helper class from `cpp_pubsub` to `rtpkg`.
- Update `rtpkg` & `cpp_pubsub` CMakeLists.txt & package dependencies accordingly.