### PR TITLE
Fix gh-action config

### DIFF
--- a/.github/workflows/gh-action.yml
+++ b/.github/workflows/gh-action.yml
@@ -12,6 +12,7 @@ jobs:
            - {ROS_DISTRO: foxy, ROS_REPO: main}
     env:
       CCACHE_DIR: /github/home/.ccache                          # Directory for ccache (and how we enable ccache in industrial_ci)
+      UPSTREAM_WORKSPACE: 'req.repos'                           # Import ament_catch2 plugin
       #CODE_COVERAGE: coveralls.io                               # Select either codecov.io or coveralls.io, else comment it out
       #COVERALLS_REPO_TOKEN:  ${{ secrets.COVERALLS_TOKEN }}     # Required only for coveralls, set repo secret in settings
 
@@ -23,6 +24,8 @@ jobs:
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
+      - name: Setup Catch2                                        # Setup Catch2 in /home/runner/work/rtpkg/rtpkg/Catch2/tmp/
+        run: './scripts/setup_catch2.sh'
       # Run industrial_ci
       - uses: 'ros-industrial/industrial_ci@master'
       #- uses: 'Briancbn/industrial_ci@pr-coverage-rebased'    # For code coverage upload service, use this branch for now. Else, use the main one above.

--- a/req.repos
+++ b/req.repos
@@ -1,0 +1,5 @@
+repositories:
+  ament_cmake_catch2:
+    type: git
+    url: https://github.com/open-rmf/ament_cmake_catch2
+    version: main

--- a/rtpkg/CMakeLists.txt
+++ b/rtpkg/CMakeLists.txt
@@ -41,10 +41,11 @@ if(BUILD_TESTING)
   target_link_libraries(${PROJECT_NAME}_utest ${LIB_NAME})
 
   # Catch2 C++ unit test
+  set(Catch2_DIR /home/runner/work/rtpkg/rtpkg/Catch2/tmp/lib/cmake/Catch2/)  # Only for github action, comment out after cloning repo
   find_package(Catch2 REQUIRED)
   find_package(ament_cmake_catch2 REQUIRED)
   ament_add_catch2(${PROJECT_NAME}_catch2 test/main_catch.cpp)
-  target_link_libraries(${PROJECT_NAME}_catch2 ${LIB_NAME})
+  target_link_libraries(${PROJECT_NAME}_catch2 ${LIB_NAME} Catch2::Catch2)
 
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights

--- a/scripts/setup_catch2.sh
+++ b/scripts/setup_catch2.sh
@@ -1,0 +1,6 @@
+pwd
+git clone https://github.com/catchorg/Catch2/ -b v2.x
+cd Catch2
+mkdir tmp
+cmake -Bbuild -H. -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=tmp
+sudo cmake --build build/ --target install


### PR DESCRIPTION
- Create script to compile Catch2 locally & set to installation to `tmp/`.
- Modify CMakeList to specify the new path of `Catch2`.